### PR TITLE
Podman rootless container compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,8 @@
 FROM scratch
 MAINTAINER William Douglas <william.douglas@intel.com>
 ADD base.tar.xz /
+RUN cd /etc && \
+    ln -s ../usr/share/defaults/etc/passwd /etc/ && \
+    ln -s ../usr/share/defaults/etc/group /etc/ && \
+    ln -s ../usr/share/defaults/etc/shadow /etc/
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM scratch
 MAINTAINER William Douglas <william.douglas@intel.com>
 ADD base.tar.xz /
 RUN cd /etc && \
-    cp ../usr/share/defaults/etc/passwd /etc/ && \
-    cp ../usr/share/defaults/etc/group /etc/ && \
-    cp ../usr/share/defaults/etc/shadow /etc/
+    grep root /usr/share/defaults/etc/passwd > /etc/passwd && \
+    grep root /usr/share/defaults/etc/group > /etc/group && \
+    grep root /usr/share/defaults/etc/shadow > /etc/shadow
 CMD ["/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM scratch
 MAINTAINER William Douglas <william.douglas@intel.com>
 ADD base.tar.xz /
 RUN cd /etc && \
-    ln -s ../usr/share/defaults/etc/passwd /etc/ && \
-    ln -s ../usr/share/defaults/etc/group /etc/ && \
-    ln -s ../usr/share/defaults/etc/shadow /etc/
+    cp ../usr/share/defaults/etc/passwd /etc/ && \
+    cp ../usr/share/defaults/etc/group /etc/ && \
+    cp ../usr/share/defaults/etc/shadow /etc/
 CMD ["/bin/bash"]


### PR DESCRIPTION
Hi all,

right now the clearlinux docker image is not compatible with rootless podman usage:

```shell
~$ podman run -ti --userns=keep-id --user root:root --privileged docker.io/library/clearlinux bash  
Error: unable to find user root: no matching entries in passwd file
```

This happens because podman searches for the user to use (speficied in --user) in `/etc/passwd` which clearlinux does not have, as it uses instead `/usr/share/defaults/etc/`

As stated here: https://github.com/containers/podman/issues/7773#issuecomment-698896262
This is not really a bug on the podman side, as for this Merge: [containers/podman#7516 ](https://github.com/containers/podman/pull/7516) they fixed the error of starting the container without an /etc/passwd file, but it is still not compatible with the specification of --user flag.


With this pull request I wanted to grant compatibility with how podman (and containerd) work for rootless containers.
This would also allow for the creation of pet-containers fixing this issue: https://github.com/89luca89/distrobox/issues/105